### PR TITLE
convert 'interface{}' to '[]byte'

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -35,16 +35,11 @@ type Datastore struct {
 	ttl    time.Duration
 }
 
-func (ds *Datastore) Put(key datastore.Key, value interface{}) error {
+func (ds *Datastore) Put(key datastore.Key, value []byte) error {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
 
-	data, ok := value.([]byte)
-	if !ok {
-		return ErrInvalidType
-	}
-
-	ds.client.Append("SET", key.String(), data)
+	ds.client.Append("SET", key.String(), value)
 	if ds.ttl != 0 {
 		ds.client.Append("EXPIRE", key.String(), ds.ttl.Seconds())
 	}
@@ -59,7 +54,7 @@ func (ds *Datastore) Put(key datastore.Key, value interface{}) error {
 	return nil
 }
 
-func (ds *Datastore) Get(key datastore.Key) (value interface{}, err error) {
+func (ds *Datastore) Get(key datastore.Key) (value []byte, err error) {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
 	return ds.client.Cmd("GET", key.String()).Bytes()

--- a/redis_test.go
+++ b/redis_test.go
@@ -26,7 +26,7 @@ func TestPutGetBytes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Compare(v.([]byte), val) != 0 {
+	if bytes.Compare(v, val) != 0 {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
When I run 'go test',It failed because the implementation doesn't match the interface.So I change the type.